### PR TITLE
2nd audit changes

### DIFF
--- a/contracts/Common/common.hpp
+++ b/contracts/Common/common.hpp
@@ -18,6 +18,8 @@ using namespace eosio;
 #define EOS_SYMBOL symbol("EOS", EOS_PRECISION)
 #define MAX_AMOUNT asset::max_amount
 #define MAX_RATE 1000000 /* up to 1M tokens per EOS */
+#define STAKE_ACCOUNT "eosio.stake"_n
+#define RAM_ACCOUNT "eosio.ram"_n
 
 struct account {
     asset    balance;

--- a/contracts/Network/Network.hpp
+++ b/contracts/Network/Network.hpp
@@ -36,6 +36,7 @@ CONTRACT Network : public contract {
 
         TABLE reserve {
             name        contract;
+            uint64_t    num_tokens;
             uint64_t    primary_key() const { return contract.value; }
         };
 

--- a/contracts/Reserve/AmmReserve/AmmReserve.cpp
+++ b/contracts/Reserve/AmmReserve/AmmReserve.cpp
@@ -64,7 +64,7 @@ ACTION AmmReserve::setparams(double r,
                              name   fee_wallet) {
     get_state_assert_admin();
 
-    eosio_assert(r > 0 && r < 100.0, "illegal r");
+    eosio_assert(r >= 0, "illegal r");
     eosio_assert(p_min > 0, "illegal p_min");
 
     eosio_assert(max_eos_cap_buy.is_valid() && max_eos_cap_buy.amount > 0,
@@ -80,8 +80,7 @@ ACTION AmmReserve::setparams(double r,
 
     eosio_assert(max_sell_rate > 0, "illegal max_sell_rate");
     eosio_assert(min_sell_rate >= 0, "illegal min_sell_rate");
-    eosio_assert(min_sell_rate < max_sell_rate, "min_sell_rate not smaller than max_sell_rate");
-
+    eosio_assert(min_sell_rate <= max_sell_rate, "max_sell_rate smaller than min_sell_rate ");
 
     params_type params_inst(_self, _self.value);
     params new_params;

--- a/contracts/Reserve/AmmReserve/AmmReserve.cpp
+++ b/contracts/Reserve/AmmReserve/AmmReserve.cpp
@@ -64,11 +64,24 @@ ACTION AmmReserve::setparams(double r,
                              name   fee_wallet) {
     get_state_assert_admin();
 
-    eosio_assert(profit_percent < 100.0, "illegal profit_percent");
-    eosio_assert(min_sell_rate < max_sell_rate, "min_sell_rate not smaller than max_sell_rate");
+    eosio_assert(r > 0 && r < 100.0, "illegal r");
+    eosio_assert(p_min > 0, "illegal p_min");
+
+    eosio_assert(max_eos_cap_buy.is_valid() && max_eos_cap_buy.amount > 0,
+                 "illegal max_eos_cap_buy");
+    eosio_assert(max_eos_cap_sell.is_valid() && max_eos_cap_sell.amount > 0,
+                 "illegal max_eos_cap_sell");
+
+    eosio_assert(profit_percent >= 0 && profit_percent < 100.0, "illegal profit_percent");
+    eosio_assert(ram_fee >= 0, "illegal ram_fee");
     if (profit_percent || ram_fee) {
         eosio_assert(((fee_wallet != name()) && (fee_wallet != "eosio"_n)), "no fee wallet");
     }
+
+    eosio_assert(max_sell_rate > 0, "illegal max_sell_rate");
+    eosio_assert(min_sell_rate >= 0, "illegal min_sell_rate");
+    eosio_assert(min_sell_rate < max_sell_rate, "min_sell_rate not smaller than max_sell_rate");
+
 
     params_type params_inst(_self, _self.value);
     params new_params;
@@ -135,8 +148,9 @@ ACTION AmmReserve::getconvrate(asset src) {
 ACTION AmmReserve::withdraw(name to, asset quantity, name dest_contract, string memo) {
     eosio_assert(is_account(to), "to account does not exist");
     eosio_assert(is_account(dest_contract), "dest contract does not exist");
+    eosio_assert(quantity.is_valid() && quantity.amount > 0, "illegal quantity");
 
-    auto state_inst = get_state_assert_admin();
+    get_state_assert_admin();
     async_pay(_self, to, quantity, dest_contract, memo);
 }
 
@@ -230,7 +244,7 @@ void AmmReserve::trade(name from, asset src, string memo, name code, state &stat
     eosio_assert(conversion_rate > 0, "conversion rate must be bigger than 0");
     eosio_assert(conversion_rate < MAX_RATE, "fail overflow validation");
 
-    async_pay(_self, receiver, dest, dest_contract, "");
+    async_pay(_self, receiver, dest, dest_contract, "trade dest");
 
     asset charged_fee_asset = asset(damount_to_amount(charged_fee, EOS_PRECISION), EOS_SYMBOL);
     if (charged_fee_asset.amount > 0) {
@@ -255,8 +269,8 @@ void AmmReserve::transfer(name from, name to, asset quantity, string memo) {
     }
 
     auto state = state_inst.get();
-    if (from == state.admin) {
-        /* admin can deposit funds, but not trade */
+    if (from == state.admin || from == STAKE_ACCOUNT || from == RAM_ACCOUNT) {
+        /* admin and system accounts can deposit funds, but not trade */
         return;
     } else {
         trade(from, quantity, memo, _code, state);

--- a/tests/network.js
+++ b/tests/network.js
@@ -413,7 +413,7 @@ describe('as admin', () => {
             reservesPerTable = await networkData.eos.getTableRows({code: networkData.account, scope: networkData.account, table: 'reservespert', json: true});
             assert.equal(reservesPerTable["rows"].length, 0)
         })
-        it('remove a pair from a reserve that does not hold that pair does nothing', async function() {
+        it('remove a pair from a reserve that does not hold that pair reverts', async function() {
             /* start with two different pairs */
             await networkAsAdmin.listpairres({add: 1, reserve:reserve1Data.account, token_symbol:"4,SYS", token_contract:tokenData.account},{authorization: `${networkAdminData.account}@active`});
             await networkAsAdmin.listpairres({add: 1, reserve:reserve2Data.account, token_symbol:"3,TOKA", token_contract:tokenData.account},{authorization: `${networkAdminData.account}@active`});
@@ -423,8 +423,10 @@ describe('as admin', () => {
             assert.equal(reservesPerTable["rows"][0].reserve_contracts[0], reserve1Data.account)
             assert.equal(reservesPerTable["rows"][0].reserve_contracts.length, 1)
 
-            /* remove non existing pair and see all is the same */
-            await networkAsAdmin.listpairres({add: 0, reserve:reserve1Data.account, token_symbol:"3,TOKA", token_contract:tokenData.account},{authorization: `${networkAdminData.account}@active`});
+            /* remove non existing pair and see it reverts */
+            const p = networkAsAdmin.listpairres({add: 0, reserve:reserve1Data.account, token_symbol:"3,TOKA", token_contract:tokenData.account},{authorization: `${networkAdminData.account}@active`});
+            await ensureContractAssertionError(p, "not listed in reserve");
+
             reservesPerTable = await networkData.eos.getTableRows({code: networkData.account, scope: networkData.account, table: 'reservespert', json: true});
             assert.equal(reservesPerTable["rows"].length, 2)
             assert.equal(reservesPerTable["rows"][0].symbol, "4,SYS")


### PR DESCRIPTION
Allow accepting funds from ram sell and cpu/bandwitdth unstaking.

When rmoving reserve, verify it does not have listed tokens.

Additional input validations.